### PR TITLE
Update CVCalendarManager.swift

### DIFF
--- a/CVCalendar/CVCalendarManager.swift
+++ b/CVCalendar/CVCalendarManager.swift
@@ -227,7 +227,9 @@ class CVCalendarManager: NSObject {
     // MARK: - Util methods
     
     func componentsForDate(date: NSDate) -> NSDateComponents {
-        let units = NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitWeekOfYear | NSCalendarUnit.CalendarUnitDay
+        let units = NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | 
+        NSCalendarUnit.CalendarUnitWeekOfYear | NSCalendarUnit.CalendarUnitDay | NSCalendarUnit.CalendarUnitWeekOfMonth
+        
         let components = self.calendar!.components(units, fromDate: date)
         
         return components


### PR DESCRIPTION
Add NSCalendarUnit.CalendarUnitWeekOfMonth to the units  in the func componentsForDate(date: NSDate) -> NSDateComponents, if miss this constants, it will get  indeterminate value from components.weekOfMonth which  in the func presentedWeekView() -> WeekView, and resulting in  an array bounds error with "let weekView = presentedMonthView.weekViews![index]"
